### PR TITLE
downgrade node-fetch, audit fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: 'node-fetch'
+        # For node-fetch, ignore all updates for version 3
+        versions: ['3.x']
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: 'github-actions'

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "date-fns": "^2.23.0",
                 "dotenv": "^10.0.0",
                 "libxmljs2": "^0.28.0",
-                "node-fetch": "^3.0.0",
+                "node-fetch": "^2.6.1",
                 "redis": "^3.1.2",
                 "underscore": "^1.13.1",
                 "validate-with-xmllint": "github:IATI/validate-with-xmllint#useLocally",
@@ -98,14 +98,6 @@
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@azure/core-http/node_modules/node-fetch": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-            "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
-            "engines": {
-                "node": "4.x || >=6.0.0"
             }
         },
         "node_modules/@azure/core-http/node_modules/tslib": {
@@ -243,14 +235,6 @@
             },
             "bin": {
                 "node-pre-gyp": "bin/node-pre-gyp"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-            "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
-            "engines": {
-                "node": "4.x || >=6.0.0"
             }
         },
         "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
@@ -1110,14 +1094,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/data-uri-to-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/date-fns": {
             "version": "2.23.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
@@ -1744,27 +1720,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
-        },
-        "node_modules/fetch-blob": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-            "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "dependencies": {
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
-            }
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -3089,19 +3044,11 @@
             "dev": true
         },
         "node_modules/node-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-            "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-            "dependencies": {
-                "data-uri-to-buffer": "^3.0.1",
-                "fetch-blob": "^3.1.2"
-            },
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+            "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
+                "node": "4.x || >=6.0.0"
             }
         },
         "node_modules/nopt": {
@@ -4062,9 +4009,9 @@
             "dev": true
         },
         "node_modules/tar": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
-            "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
+            "version": "6.1.11",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
@@ -4244,14 +4191,6 @@
             "resolved": "git+ssh://git@github.com/IATI/validate-with-xmllint.git#004fdee3f07e7f89cf202ffab7e4becc1a15a69b",
             "hasInstallScript": true,
             "license": "MIT"
-        },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-            "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q==",
-            "engines": {
-                "node": ">= 8"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -4560,11 +4499,6 @@
                 "xml2js": "^0.4.19"
             },
             "dependencies": {
-                "node-fetch": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-                    "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
-                },
                 "tslib": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -4692,11 +4626,6 @@
                 "tar": "^6.1.0"
             },
             "dependencies": {
-                "node-fetch": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-                    "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
-                },
                 "semver": {
                     "version": "7.3.5",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -5369,11 +5298,6 @@
                 "which": "^2.0.1"
             }
         },
-        "data-uri-to-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
-        },
         "date-fns": {
             "version": "2.23.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
@@ -5863,14 +5787,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
-        },
-        "fetch-blob": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-            "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-            "requires": {
-                "web-streams-polyfill": "^3.0.3"
-            }
         },
         "figures": {
             "version": "3.2.0",
@@ -6845,13 +6761,9 @@
             "dev": true
         },
         "node-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-            "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-            "requires": {
-                "data-uri-to-buffer": "^3.0.1",
-                "fetch-blob": "^3.1.2"
-            }
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+            "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
         },
         "nopt": {
             "version": "5.0.0",
@@ -7596,9 +7508,9 @@
             }
         },
         "tar": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
-            "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
+            "version": "6.1.11",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
             "requires": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
@@ -7743,11 +7655,6 @@
         "validate-with-xmllint": {
             "version": "git+ssh://git@github.com/IATI/validate-with-xmllint.git#004fdee3f07e7f89cf202ffab7e4becc1a15a69b",
             "from": "validate-with-xmllint@github:IATI/validate-with-xmllint#useLocally"
-        },
-        "web-streams-polyfill": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-            "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "date-fns": "^2.23.0",
         "dotenv": "^10.0.0",
         "libxmljs2": "^0.28.0",
-        "node-fetch": "^3.0.0",
+        "node-fetch": "^2.6.1",
         "redis": "^3.1.2",
         "underscore": "^1.13.1",
         "validate-with-xmllint": "github:IATI/validate-with-xmllint#useLocally",


### PR DESCRIPTION
v3 of node-fetch is ESM modules only and not compatible with this application (using require). 
https://github.com/node-fetch/node-fetch/blob/HEAD/docs/v3-UPGRADE-GUIDE.md

Downgraded it and told dependabot to ignore v3 for node-fetch.