### PR TITLE
feat/selectively schema validate inline

### DIFF
--- a/services/validationService.js
+++ b/services/validationService.js
@@ -139,6 +139,7 @@ exports.validate = async (context, req) => {
             codelistTime: '',
             ruleAndSchemaTime: '',
             exitCategory: '',
+            schemaErrorsPresent: '',
         };
 
         // Metric: File Size (MiB)
@@ -180,6 +181,7 @@ exports.validate = async (context, req) => {
             };
         }
 
+        let xmlDoc;
         try {
             ({
                 fileType: state.fileType,
@@ -187,6 +189,7 @@ exports.validate = async (context, req) => {
                 generatedDateTime: state.generatedDateTime,
                 supportedVersion: state.supportedVersion,
                 isIati: state.isIati,
+                xmlDoc,
             } = getFileInformation(body));
         } catch (error) {
             let errContext;
@@ -287,6 +290,10 @@ exports.validate = async (context, req) => {
             return;
         }
 
+        // File level Schema Check
+        state.schemaErrorsPresent = !xmlDoc.validate(getSchema(state.fileType, state.iatiVersion));
+        xmlDoc = null;
+
         // Codelist Validation
         const codelistStart = getStartTime();
 
@@ -308,7 +315,7 @@ exports.validate = async (context, req) => {
             body,
             state.fileType,
             idSets,
-            getSchema(state.fileType, state.iatiVersion),
+            state.schemaErrorsPresent ? getSchema(state.fileType, state.iatiVersion) : '',
             showDetails,
             showElementMeta
         );

--- a/services/validationService.js
+++ b/services/validationService.js
@@ -136,7 +136,9 @@ exports.validate = async (context, req) => {
             supportedVersion: '',
             isIati: '',
             fileInfoTime: '',
+            fileSchemaTime: '',
             codelistTime: '',
+            ruleTime: '',
             ruleAndSchemaTime: '',
             exitCategory: '',
             schemaErrorsPresent: '',
@@ -291,8 +293,10 @@ exports.validate = async (context, req) => {
         }
 
         // File level Schema Check
+        const fileSchemaStart = getStartTime();
         state.schemaErrorsPresent = !xmlDoc.validate(getSchema(state.fileType, state.iatiVersion));
         xmlDoc = null;
+        state.fileSchemaTime = getElapsedTime(fileSchemaStart);
 
         // Codelist Validation
         const codelistStart = getStartTime();
@@ -320,8 +324,15 @@ exports.validate = async (context, req) => {
             showElementMeta
         );
 
-        state.ruleAndSchemaTime = getElapsedTime(ruleStart);
-        context.log({ name: 'Ruleset Validate Time (s)', value: state.ruleAndSchemaTime });
+        if (state.schemaErrorsPresent) {
+            state.ruleAndSchemaTime = getElapsedTime(ruleStart);
+        } else {
+            state.ruleTime = getElapsedTime(ruleStart);
+        }
+        context.log({
+            name: `Ruleset ${state.schemaErrorsPresent ? 'and Schema ' : ''}Validate Time (s)`,
+            value: state.ruleAndSchemaTime,
+        });
 
         // combine all types of errors
         const combinedErrors = [


### PR DESCRIPTION
[Trello](https://trello.com/c/Q04XIUIG/276-alv-ii-evaluate-critical-errors-at-activity-level-in-the-validator-api)
- only run schema validation at activity level if schema errors present at file level
- update time logging for new schema validation method
