### PR TITLE
Remove code for deprecated codelist check for country-budget-items/budget-item/@code

### DIFF
--- a/services/codelistValidator.js
+++ b/services/codelistValidator.js
@@ -143,34 +143,6 @@ exports.validateCodelists = async (body, version, showDetails) => {
                         const curValue = newValue.$[attribute].toString();
                         const valid = allowedCodes.includes(curValue);
                         if (!valid) cacheError(codelistDefinition, xpath, curValue, attribute);
-
-                        // edge case for country-budget-items/budget-item
-                        // Remove in v3.x of standard
-                        if (
-                            xpath === '/iati-activities/iati-activity/country-budget-items' &&
-                            attribute === 'vocabulary' &&
-                            curValue === '1'
-                        ) {
-                            const codelistSubDefinition =
-                                codelistRules[
-                                    '/iati-activities/iati-activity/country-budget-items/budget-item'
-                                ];
-                            const allowedBudgetCodes =
-                                codelistSubDefinition.code.conditions.mapping['1'].allowedCodes;
-                            newValue['budget-item'].forEach((item) => {
-                                const value = item.$.code;
-                                const validBudget = allowedBudgetCodes.includes(value.toString());
-                                if (!validBudget)
-                                    cacheError(
-                                        codelistSubDefinition,
-                                        '/iati-activities/iati-activity/country-budget-items/budget-item',
-                                        value,
-                                        'code',
-                                        'vocabulary',
-                                        '1'
-                                    );
-                            });
-                        }
                     }
                 });
             }


### PR DESCRIPTION
[Trello](https://trello.com/c/Z7x6LXVK)

Due to this codelist mapping being removed: https://github.com/IATI/IATI-Codelists/pull/266
From: https://github.com/IATI/IATI-Codelists/issues/138